### PR TITLE
Power cap fixes required for the 5.0 kernel

### DIFF
--- a/powercap.hpp
+++ b/powercap.hpp
@@ -4,6 +4,7 @@
 
 #include "occ_status.hpp"
 
+#include <filesystem>
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/bus/match.hpp>
 
@@ -95,6 +96,18 @@ class PowerCap
      * @param[in]  pcapValue - Power cap value to write to OCC
      */
     void writeOcc(uint32_t pcapValue);
+
+    /**
+     * @brief Returns the filename to use for the user power cap
+     *
+     * The file is of the form "powerX_cap_user", where X is any
+     * number.
+     *
+     * @param[in] path - The directory to look for the file in
+     *
+     * @return std::string - The filename, or empty string if not found.
+     */
+    std::string getPcapFilename(const std::filesystem::path& path);
 
     /** @brief Reference to sdbus **/
     sdbusplus::bus::bus& bus;


### PR DESCRIPTION
The OCC device driver changed in the 5.0 kernel which requires
2 user space changes when setting the OCC user power cap:

1) The file name to write to changed to powerX_cap_user, where
   X is some number.
2) The value changed to microWatts, from Watts.

This commit uses a regular expression to find the filename.  An
alternative method would have been to find the X value by finding
which powerX_label file contained the word 'system'.

Tested: Ran the ipmitool dcmi commands to set and activate the
        power cap.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I4f086b2d80944c3bd0ebc627e4df92935d27a5a3