### PR TITLE
Use experimental::filesystem for the power cap

### DIFF
--- a/powercap.cpp
+++ b/powercap.cpp
@@ -21,7 +21,7 @@ constexpr auto POWER_CAP_PROP = "PowerCap";
 constexpr auto POWER_CAP_ENABLE_PROP = "PowerCapEnable";
 
 using namespace phosphor::logging;
-namespace fs = std::filesystem;
+namespace fs = std::experimental::filesystem;
 
 std::string PowerCap::getService(std::string path, std::string interface)
 {

--- a/powercap.hpp
+++ b/powercap.hpp
@@ -4,7 +4,7 @@
 
 #include "occ_status.hpp"
 
-#include <filesystem>
+#include <experimental/filesystem>
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/bus/match.hpp>
 
@@ -107,7 +107,8 @@ class PowerCap
      *
      * @return std::string - The filename, or empty string if not found.
      */
-    std::string getPcapFilename(const std::filesystem::path& path);
+    std::string
+        getPcapFilename(const std::experimental::filesystem::path& path);
 
     /** @brief Reference to sdbus **/
     sdbusplus::bus::bus& bus;


### PR DESCRIPTION
Using std::filesystem changes the behavior of the path::/ operator
compared to std::experimental::filesystem, and this doesn't work
with the existing code. Specifically, appending a path that starts with
a '/' which is done here completely overwrites the base path instead
of appending.

Change back to using
std::experimental::filesytem to keep things consistent with the rest of
the code base.  If a move to std::filesystem is desired in the future the
whole codebase can be changed and tested at once.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I2b1cbbbc0ab13f1a0a5bf85494302e68e7adcab3

https://gerrit.openbmc-project.xyz/c/openbmc/openpower-occ-control/+/23844