### PR TITLE
Block USR1 signal until the signal handler is enabled

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -17,6 +17,9 @@ using InternalFailure =
 
 int main(int /*argc*/, char** /*argv[]*/)
 {
+    // Block SIGUSR1 untill the handler is ready
+    stdplus::signal::block(SIGUSR1);
+
     auto& bus = open_power::occ::utils::getBus();
 
     // Need sd_event to watch for OCC device errors
@@ -49,7 +52,6 @@ int main(int /*argc*/, char** /*argv[]*/)
     try
     {
         // Enable SIGUSR1 handling to collect data on dump request
-        stdplus::signal::block(SIGUSR1);
         sdeventplus::source::Signal sigUsr1(
             eventP.get(), SIGUSR1,
             std::bind(&open_power::occ::Manager::collectDumpData, &mgr,


### PR DESCRIPTION
The USR1 signal is used to collect dump data from the occ-control app. The signal was not being blocked until just before the handler was started.
Tester hit a window where the app got started, and then the signal came in before the handler was enabled, so the app was killed instead of doing the data collection.

This change will block the USR1 signal as first thing in the start of the app, preventing the app from being killed.