### PR TITLE
Fix stale hwmon path cache in PowerCap object

### DIFF
--- a/occ_manager.cpp
+++ b/occ_manager.cpp
@@ -1160,7 +1160,17 @@ void Manager::updatePcapBounds(bool& parmsChanged, uint32_t& capSoftMin,
 {
     if (pcap)
     {
-        pcap->updatePcapBounds(parmsChanged, capSoftMin, capHardMin, capMax);
+        for (auto& obj : statusObjects)
+        {
+            if (obj->isMasterOcc())
+            {
+                lg2::info("updatePcapBounds: setting OCC{INST} as pcap master",
+                          "INST", obj->getOccInstanceID());
+                pcap->setMasterOccObj(*obj);
+                break;
+            }
+        }
+        pcap->updatePcapBounds();
     }
 }
 

--- a/powercap.cpp
+++ b/powercap.cpp
@@ -217,27 +217,35 @@ bool PowerCap::getPcapEnabled()
 
 fs::path PowerCap::getPcapFilename(const std::regex& expr)
 {
-    if (pcapBasePathname.empty())
+    if (masterOccObj.has_value())
     {
-        pcapBasePathname = occStatus.getHwmonPath();
-    }
-
-    if (fs::exists(pcapBasePathname))
-    {
-        // Search for pcap file based on the supplied expr
-        for (auto& file : fs::directory_iterator(pcapBasePathname))
+        // Refresh the path if it's empty or no longer exists
+        // (hwmon numbers can change after reboot/driver reload)
+        if (pcapBasePathname.empty() || !fs::exists(pcapBasePathname))
         {
-            if (std::regex_search(file.path().string(), expr))
+            pcapBasePathname = masterOccObj->get().getHwmonPath();
+            lg2::info("getPcapFilename: updated OCC{INST} path to {BASE}",
+                      "INST", masterOccObj->get().getOccInstanceID(), "BASE",
+                      pcapBasePathname);
+        }
+
+        if (fs::exists(pcapBasePathname))
+        {
+            // Search for pcap file based on the supplied expr
+            for (auto& file : fs::directory_iterator(pcapBasePathname))
             {
-                // Found match
-                return file;
+                if (std::regex_search(file.path().string(), expr))
+                {
+                    // Found match
+                    return file;
+                }
             }
         }
-    }
-    else
-    {
-        lg2::error("Power Cap base filename not found: {FILE}", "FILE",
-                   pcapBasePathname);
+        else
+        {
+            lg2::error("Power Cap base filename not found: {FILE}", "FILE",
+                       pcapBasePathname);
+        }
     }
 
     // return empty path


### PR DESCRIPTION
After a hardware change, the kernel may assign a different hwmon device number to the OCC (e.g., changing from hwmon10 to hwmon0). The PowerCap object was caching the hwmon base path and never refreshing it, causing errors like:

Power Cap base filename not found:
    /sys/bus/platform/drivers/occ-hwmon/occ-hwmon.1/hwmon/hwmon10

The fix adds a check to refresh the cached path whenever it becomes invalid, similar to how Status::getHwmonPath() already handles this.

Now the code checks if the cached path exists before using it, and re-queries the current hwmon path from the Status object if needed.

Tested on Rainier:
```
1. Boot system and then power off
2. Remove OCC0 device: echo "occ-hwmon.1" > /sys/bus/platform/drivers/occ-hwmon/unbind
3. Remove first power supply: echo "3-0068" > /sys/bus/i2c/drivers/ibm-cffps/unbind
4. Re-enable OCC device: echo "occ-hwmon.1" > /sys/bus/platform/drivers/occ-hwmon/bind
5. Boot system again
6. Verify paths were updated

Mar 18 14:39:05 p11bmc openpower-occ-control[6430]: PLDM: OCC0 is RUNNING
Mar 18 14:39:05 p11bmc openpower-occ-control[6430]: Status::occActive OCC0 changed to True
Mar 18 14:39:05 p11bmc openpower-occ-control[6430]: updatePcapBounds: setting OCC0 as pcap master
Mar 18 14:39:05 p11bmc openpower-occ-control[6430]: getPcapFilename no longer exists
Mar 18 14:39:05 p11bmc openpower-occ-control[6430]: Status::getHwmonPath(): path no longer exists: /sys/bus/platform/drivers/occ-hwmon/occ-hwmon.1/hwmon/hwmon15
Mar 18 14:39:05 p11bmc openpower-occ-control[6430]: getPcapFilename updated OCC0 path to /sys/bus/platform/drivers/occ-hwmon/occ-hwmon.1/hwmon/hwmon7
Mar 18 14:39:05 p11bmc openpower-occ-control[6430]: Manager: OCCs will be polled every 5 seconds
Power cap was successfully sent to the OCC:
Mar 18 14:46:30 p11bmc openpower-occ-control[6430]: Power Cap Property Change (cap=3000W (input), enabled=True)
Mar 18 14:46:30 p11bmc openpower-occ-control[6430]: getPcapFilename found OCC0 is /sys/bus/platform/drivers/occ-hwmon/occ-hwmon.1/hwmon/hwmon7
Mar 18 14:46:30 p11bmc openpower-occ-control[6430]: Writing 2700000000uW to /sys/bus/platform/drivers/occ-hwmon/occ-hwmon.1/hwmon/hwmon7/power15_cap_user
```

Change-Id: Id2bfe937fba6ab38a119ff4b7032f915ca0e5fba